### PR TITLE
feat: add code sandbox demo and recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ A modern, mobile-first portfolio website built with progressive web app capabili
 ├── manifest.json (PWA configuration)
 └── sw.js (service worker)
 
+## Recording Demos
+
+- Run `node scripts/generate-gif-demo.js --out=assets/demos/demo.gif` to capture a short animated preview using headless Chrome.
+- For higher quality recordings use OBS Studio or run the script in CI with headless Chrome and ffmpeg.
+
 ## Deployment
 
 1. Upload all files to your web server

--- a/components/code-demo.html
+++ b/components/code-demo.html
@@ -1,0 +1,23 @@
+<div class="code-demo">
+  <iframe src="" loading="lazy" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>
+  <div class="code-demo__fallback" style="display:none">
+    <pre><code class="language-js">// Example snippet
+console.log('Hello from demo');</code></pre>
+    <button class="run-sandbox">Run in sandbox</button>
+  </div>
+</div>
+<script>
+(function(){
+  const root = document.currentScript.previousElementSibling;
+  const frame = root.querySelector('iframe');
+  const fallback = root.querySelector('.code-demo__fallback');
+  frame.addEventListener('error', () => {
+    frame.style.display = 'none';
+    fallback.style.display = 'block';
+  });
+  fallback.querySelector('.run-sandbox').addEventListener('click', () => {
+    const url = frame.getAttribute('src') || 'https://stackblitz.com/';
+    window.open(url, '_blank');
+  });
+})();
+</script>

--- a/scripts/generate-gif-demo.js
+++ b/scripts/generate-gif-demo.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const puppeteer = require('puppeteer');
+const { PuppeteerScreenRecorder } = require('puppeteer-screen-recorder');
+
+async function main() {
+  const outArg = process.argv.find(a => a.startsWith('--out=')) || '--out=assets/demos/demo.gif';
+  const outGif = outArg.split('=')[1];
+  const outMp4 = outGif.replace(/\.gif$/i, '.mp4');
+  const outDir = path.dirname(outGif);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox','--disable-setuid-sandbox'], defaultViewport: { width: 1280, height: 720 }});
+  const page = await browser.newPage();
+  const indexPath = path.join(__dirname, '..', 'index.html');
+  await page.goto('file://' + indexPath, { waitUntil: 'networkidle0' });
+
+  // Scroll the page
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await page.waitForTimeout(500);
+
+  // Open demo panel if available
+  const demoButton = await page.$('.code-demo .run-sandbox');
+  if (demoButton) {
+    await demoButton.click();
+    await page.waitForTimeout(500);
+  }
+
+  // Record the interaction
+  const recorder = new PuppeteerScreenRecorder(page);
+  await recorder.start(outMp4);
+  await page.waitForTimeout(3000);
+  await recorder.stop();
+  await browser.close();
+
+  try {
+    execSync(`ffmpeg -y -i ${outMp4} ${outGif}`, { stdio: 'inherit' });
+  } catch (err) {
+    console.error('ffmpeg conversion failed:', err.message);
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `code-demo.html` component with iframe and Prism-powered fallback
- add Puppeteer script to record demo GIFs/MP4s
- document demo recording workflow in README

## Testing
- `npm test` (fails: Error: no test specified)
- `node scripts/generate-gif-demo.js --out=assets/demos/demo.gif`


------
https://chatgpt.com/codex/tasks/task_e_68b71902b72083289cd6fcf7f1230d33