### PR TITLE
Add docs for repo selection and AI integration

### DIFF
--- a/docs/AI_INTEGRATION.md
+++ b/docs/AI_INTEGRATION.md
@@ -1,0 +1,47 @@
+# AI Integration
+
+The `/api/ai` endpoint proxies requests to configured AI providers.
+
+## Environment Variables
+
+Set the following variables to enable providers:
+
+- `OPENAI_API_KEY` – API key for OpenAI.
+- `ANTHROPIC_API_KEY` – API key for Anthropic.
+- `GEMINI_API_KEY` – API key for Google Gemini.
+- `AI_DEFAULT_PROVIDER` – provider used when no `provider` is specified.
+
+## Provider Mappings
+
+The service maps provider names to their respective APIs:
+
+| Provider    | Environment Variable  | Base URL |
+|-------------|-----------------------|----------|
+| `openai`    | `OPENAI_API_KEY`      | `https://api.openai.com/v1` |
+| `anthropic` | `ANTHROPIC_API_KEY`   | `https://api.anthropic.com` |
+| `gemini`    | `GEMINI_API_KEY`      | `https://generativelanguage.googleapis.com/v1beta` |
+
+## Example Calls
+
+### curl
+
+```bash
+curl -X POST https://example.com/api/ai \
+  -H "Content-Type: application/json" \
+  -d '{"provider":"openai","model":"gpt-4","messages":[{"role":"user","content":"Hello"}]}'
+```
+
+### JavaScript
+
+```js
+const res = await fetch('/api/ai', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    provider: 'openai',
+    model: 'gpt-4',
+    messages: [{ role: 'user', content: 'Hello' }]
+  })
+});
+const data = await res.json();
+```

--- a/docs/AI_INTEGRATION.md
+++ b/docs/AI_INTEGRATION.md
@@ -43,5 +43,9 @@ const res = await fetch('/api/ai', {
     messages: [{ role: 'user', content: 'Hello' }]
   })
 });
+if (!res.ok) {
+  const errorText = await res.text();
+  throw new Error(`API request failed with status ${res.status}: ${errorText}`);
+}
 const data = await res.json();
 ```

--- a/docs/REPO_SELECTION.md
+++ b/docs/REPO_SELECTION.md
@@ -1,0 +1,23 @@
+# Repository Selection
+
+This document describes the heuristics used to pick repositories and how to override them.
+
+## Scoring Heuristics
+
+Each candidate repository receives a score composed of:
+
+- **Stars** – weight of 2 per star.
+- **Recent activity** – repositories updated within the last month receive +10 points.
+- **Topic match** – +5 for each matching topic keyword.
+- **Forks** – +1 per fork.
+
+The selection process sums these values and picks the highest-scoring repository.
+
+## Overriding Picks
+
+To manually select a repository:
+
+1. Set the `REPO_OVERRIDE` environment variable to the desired repository URL or name.
+2. Run the selection script; the override value will be used instead of the computed score.
+
+Alternatively, supply `--repo <name>` on the command line to bypass scoring entirely.


### PR DESCRIPTION
## Summary
- document repository scoring heuristics and manual overrides
- explain AI provider environment variables, mappings, and example /api/ai calls

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b71909f23c83288631cfd612342b29