### PR TITLE
chore: bump GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
@@ -20,7 +20,7 @@ jobs:
       - name: Generate GIF demo
         run: node scripts/generate-gif-demo.js
       - name: Upload GIF artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gif-demo
           path: demo.gif


### PR DESCRIPTION
## Summary
- chore: update `actions/checkout`, `actions/setup-node`, and `actions/upload-artifact` to latest versions

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Archangel13GTL.github.io/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b71e22ba808328be92425838aaf159