### PR TITLE
Add build and deploy GitHub Pages workflow

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,0 +1,45 @@
+name: CI / Build & Deploy
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies (ci if lockfile exists, else install)
+        run: |
+          if [ -f ./package-lock.json ] || [ -f ./npm-shrinkwrap.json ] || [ -f ./yarn.lock ]; then
+            echo "Lockfile found — running npm ci"
+            npm ci
+          else
+            echo "No lockfile — running npm install"
+            npm install
+          fi
+
+      - name: Build (only if npm run build exists)
+        run: |
+          if grep -q '"build"' package.json; then
+            npm run build
+          else
+            echo "No build script — skipping build"
+          fi
+
+      # Optional: run tests, lint, etc.
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public   # change if your build outputs to a different dir
+


### PR DESCRIPTION
## Summary
- add CI build & deploy workflow for GitHub Pages

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68b71f3705548328841e01a4aef4b4f6