### PR TITLE
fix: publish site from repo root

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -41,5 +41,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public   # change if your build outputs to a different dir
+          publish_dir: .          # deploy from repository root
 


### PR DESCRIPTION
## Summary
- publish GitHub Pages from repository root instead of non-existent public dir

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b7208ca780832890b14005e7c5c2ad