### PR TITLE
fix: use execFileSync for gif generation

### DIFF
--- a/scripts/generate-gif-demo.js
+++ b/scripts/generate-gif-demo.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const puppeteer = require('puppeteer');
 const { PuppeteerScreenRecorder } = require('puppeteer-screen-recorder');
 


### PR DESCRIPTION
## Summary
- import `execFileSync` instead of `execSync` in `generate-gif-demo.js`
- ensure ffmpeg invocation matches the imported method

## Testing
- `node --check scripts/generate-gif-demo.js && echo SyntaxOK`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7208a8aa08328aea687a9816ef87f