### PR TITLE
Default GIF demo output to repository root

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A modern, mobile-first portfolio website built with progressive web app capabili
 
 ## Recording Demos
 
-- Run `node scripts/generate-gif-demo.js --out=assets/demos/demo.gif` to capture a short animated preview using headless Chrome.
+- Run `node scripts/generate-gif-demo.js` to capture a short animated preview using headless Chrome. Use `--out=<path>` to save to a custom location.
 - For higher quality recordings use OBS Studio or run the script in CI with headless Chrome and ffmpeg.
 
 ## Deployment

--- a/scripts/generate-gif-demo.js
+++ b/scripts/generate-gif-demo.js
@@ -6,7 +6,7 @@ const puppeteer = require('puppeteer');
 const { PuppeteerScreenRecorder } = require('puppeteer-screen-recorder');
 
 async function main() {
-  const outArg = process.argv.find(a => a.startsWith('--out=')) || '--out=assets/demos/demo.gif';
+  const outArg = process.argv.find(a => a.startsWith('--out=')) || '--out=demo.gif';
   const outGif = outArg.split('=')[1];
   const outMp4 = outGif.replace(/\.gif$/i, '.mp4');
   const outDir = path.dirname(outGif);


### PR DESCRIPTION
## Summary
- default demo gif generation to repository root
- document new default and optional custom output path in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7208bf8fc8328b31088de3b5717e0