### PR TITLE
chore: guard npm steps in workflows

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -13,11 +13,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
+        if: ${{ hashFiles('package.json') != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Install dependencies (ci if lockfile exists, else install)
+        if: ${{ hashFiles('package.json') != '' }}
         run: |
           if [ -f ./package-lock.json ] || [ -f ./npm-shrinkwrap.json ] || [ -f ./yarn.lock ]; then
             echo "Lockfile found — running npm ci"
@@ -28,6 +30,7 @@ jobs:
           fi
 
       - name: Build (only if npm run build exists)
+        if: ${{ hashFiles('package.json') != '' }}
         run: |
           if grep -q '"build"' package.json; then
             npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        if: ${{ hashFiles('package.json') != '' }}
         with:
           node-version: 20
           cache: npm
       - name: Install dependencies
+        if: ${{ hashFiles('package.json') != '' }}
         run: npm ci
       - name: Run repo-scoring
+        if: ${{ hashFiles('package.json') != '' }}
         run: npx repo-scoring
       - name: Generate GIF demo
+        if: ${{ hashFiles('package.json') != '' }}
         run: node scripts/generate-gif-demo.js
       - name: Upload GIF artifact
+        if: ${{ hashFiles('package.json') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: gif-demo


### PR DESCRIPTION
## Summary
- prevent CI workflow from running npm steps when no package.json
- guard build/deploy workflow npm steps behind package.json check

## Testing
- `npx --yes yaml-lint .github/workflows/ci.yml .github/workflows/build-deploy.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b72087fc94832880d741bdacf7ef2a