### PR TITLE
Gracefully handle missing repository data in update_links

### DIFF
--- a/update_links.py
+++ b/update_links.py
@@ -11,8 +11,12 @@ MATCH_THRESHOLD = 0.8
 
 
 def load_repos():
-    with REPO_FILE.open() as f:
-        return json.load(f)
+    try:
+        with REPO_FILE.open() as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print("Warning: repository data file not found", flush=True)
+        return []
 
 
 def normalize(s: str) -> str:
@@ -32,6 +36,10 @@ def best_scores(title: str, repo_names: list[str]):
 
 def main():
     repo_names = load_repos()
+    if not repo_names:
+        print("No repository data found. Exiting.", flush=True)
+        return
+
     index_path = Path('index.html')
     soup = BeautifulSoup(index_path.read_text(encoding='utf-8'), 'html.parser')
     section = soup.find('section', id='projects')


### PR DESCRIPTION
## Summary
- Handle missing repos.json with a warning and empty list
- Skip update when repo data is absent

## Testing
- `pytest`
- `python - <<'PY'
import update_links
print(update_links.load_repos())
PY` (with repos.json temporarily renamed)

------
https://chatgpt.com/codex/tasks/task_e_68b721b7f4188328b9d51b4821c3a888