### PR TITLE
feat: enforce Node 18 runtime for AI proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ MIT License - feel free to use and modify
 
 ## Environment Setup
 
+Ensure [Node.js](https://nodejs.org/) **18 or newer** is installed; the backend checks the runtime version at startup and exits if the requirement is not met.
+
 Configure API provider keys as environment variables before running the backend that powers `/api/ai`:
 
 ```bash

--- a/functions/ai-proxy/index.js
+++ b/functions/ai-proxy/index.js
@@ -1,3 +1,10 @@
+// Ensure a modern Node.js runtime with built-in `fetch` support.
+const [major] = process.versions.node.split('.').map(Number);
+if (major < 18) {
+  console.error(`Node.js 18 or higher is required. Detected ${process.versions.node}.`);
+  process.exit(1);
+}
+
 const express = require('express');
 const { Readable } = require('stream');
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "archangel13gtl.github.io",
+  "private": true,
+  "engines": {
+    "node": ">=18"
+  }
+}


### PR DESCRIPTION
## Summary
- enforce Node.js 18+ at runtime in the AI proxy function
- document the Node.js 18 requirement in project docs
- add package metadata specifying Node 18+

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "const [m]=process.versions.node.split('.').map(Number); if(m<18){console.error('Node too old');process.exit(1);} console.log('node version ok');"`


------
https://chatgpt.com/codex/tasks/task_e_68b721bbb75c8328bb547b4d790da4bd