### PR TITLE
Refactor logging configuration in update scripts

### DIFF
--- a/update.py
+++ b/update.py
@@ -12,8 +12,10 @@ import zipfile
 import json
 import time
 
-# Setup logging
-logging.basicConfig(level=logging.INFO, format='[%(asctime)s] [%(levelname)s] %(message)s')
+
+def configure_logging(level=logging.INFO):
+    """Configure basic logging for scripts in this module."""
+    logging.basicConfig(level=level, format='[%(asctime)s] [%(levelname)s] %(message)s')
 
 # --- CONFIGURATION ---
 
@@ -236,6 +238,8 @@ def git_commit_changes(files, message, branch):
         logging.error(f"[Error] Git operation failed: {e}")
 
 def main(dry_run=False, git_commit=False, undo=False, branch=GIT_BRANCH):
+    if not logging.getLogger().hasHandlers():
+        configure_logging()
     ensure_snippets()  # Auto-generate missing snippet files
     if undo:
         for file in HTML_FILES + OTHER_FILES:
@@ -287,6 +291,7 @@ def main(dry_run=False, git_commit=False, undo=False, branch=GIT_BRANCH):
     logging.info("\n✅ All updates applied. Review changes and redeploy.")
 
 if __name__ == "__main__":
+    configure_logging()
     parser = argparse.ArgumentParser(description="Auto-update TeNeT X portfolio site")
     parser.add_argument('--dry-run', action='store_true', help='Preview changes without writing files')
     parser.add_argument('--git-commit', action='store_true', help='Commit changes to git after update')

--- a/update_portfolio.py
+++ b/update_portfolio.py
@@ -8,8 +8,10 @@ from html.parser import HTMLParser
 import argparse
 from bs4 import BeautifulSoup  # pip install beautifulsoup4 lxml
 
-# Setup logging
-logging.basicConfig(level=logging.INFO, format='[%(asctime)s] [%(levelname)s] %(message)s')
+
+def configure_logging(level=logging.INFO):
+    """Configure basic logging for scripts in this module."""
+    logging.basicConfig(level=level, format='[%(asctime)s] [%(levelname)s] %(message)s')
 
 # --- CONFIGURATION ---
 SECTION_SNIPPETS = {
@@ -293,6 +295,8 @@ def git_commit_changes(files, message, branch):
         print(f"[Error] Git commit failed: {e}")
 
 def main(dry_run=False, git_commit=False, undo=False, branch=GIT_BRANCH):
+    if not logging.getLogger().hasHandlers():
+        configure_logging()
     ensure_snippets()
     if undo:
         for file in HTML_FILES + OTHER_FILES:
@@ -337,6 +341,7 @@ def main(dry_run=False, git_commit=False, undo=False, branch=GIT_BRANCH):
     print("Done.")
 
 if __name__ == "__main__":
+    configure_logging()
     parser = argparse.ArgumentParser()
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--git-commit", action="store_true")


### PR DESCRIPTION
## Summary
- add `configure_logging` helper to update scripts
- ensure `main()` and entry points configure logging when needed

## Testing
- `python -m py_compile update_portfolio.py update.py && echo "py_compile success"`
- `python update_portfolio.py --help`
- `python update.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b721ba7de0832880a2fe73cf1d36a7